### PR TITLE
Replace Selenium script with modern CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,94 @@
 # Google Play Store Review Extractor
 
+Modern command line utility for downloading reviews of an Android application
+from the Google Play Store. The original version of this project relied on a
+hard-coded Selenium workflow that no longer worked with the Play Store UI. This
+updated tool uses the [`google-play-scraper`](https://pypi.org/project/google-play-scraper/)
+library to access reviews directly via HTTP requests, making it faster and more
+reliable.
 
-Extract/Scrape Google Play Store Reviews of any Play Store Android Application and writes it in a csv file for further Data Exploration!
+## Features
 
-Essentials:
+- Fetch reviews for any public Play Store app by app id (e.g. `com.spotify.music`).
+- Choose the number of reviews, language, country and sort order.
+- Optional filtering by star rating.
+- Save reviews as CSV or JSON.
+- Friendly CLI with sensible defaults and helpful error messages.
 
-* Python
-* Selenium Module in Python
-* Chrome Binary
-* Chrome Webdriver
+## Requirements
 
-![Alt text](/reviews_list.PNG)
+- Python 3.9 or newer
+- [`google-play-scraper`](https://pypi.org/project/google-play-scraper/)
 
-What's next:
+Install the dependency with:
 
-* Getting App ID (com.xxxxxx) from the user
-* ~~Extracting other key elements like Rating, Review Title~~ Done!
-* Auto-Setting Number of iterations 
-* Removing Duplicate Entries
+```bash
+pip install google-play-scraper
+```
 
-### Note:
+## Usage
 
-I'm not actively maintaining this project. Please let me know if this works or not!
+Run the script directly with Python. Examples below assume the current working
+directory is the repository root.
+
+### Download reviews to CSV (default)
+
+```bash
+python reviews_extraction.py com.spotify.music --count 200
+```
+
+The command above saves up to 200 of the newest English reviews from the US
+storefront into `com_spotify_music_reviews.csv`.
+
+### Customising requests
+
+- Use `--lang` and `--country` to request a specific locale.
+- Use `--sort` with one of `relevant`, `newest` (default) or `rating`.
+- Use `--score` to keep only reviews with a given star rating (1-5).
+
+```bash
+python reviews_extraction.py com.nintendo.zara --count 100 --lang fr --country ca --sort rating --score 5
+```
+
+### JSON output
+
+```bash
+python reviews_extraction.py com.spotify.music --format json --output spotify.json
+```
+
+If `--output` is omitted when using `--format json`, the JSON document is
+written to stdout.
+
+### Overwriting files
+
+To replace an existing output file pass `--overwrite`:
+
+```bash
+python reviews_extraction.py com.spotify.music -n 50 --overwrite
+```
+
+## Output columns (CSV)
+
+The CSV writer stores the following columns:
+
+- `review_id`
+- `user_name`
+- `user_image`
+- `score`
+- `thumbs_up_count`
+- `review_created_version`
+- `app_version`
+- `content`
+- `reply_content`
+- `at` (ISO 8601 timestamp)
+- `replied_at` (ISO 8601 timestamp)
+
+## Troubleshooting
+
+- **Empty output** – the chosen locale or filters might not have any reviews.
+- **HTTP errors** – retry later; the library respects Google rate limits but the
+  Play Store occasionally blocks repeated requests temporarily.
+
+Feel free to open an issue or submit a PR if you encounter a bug or have ideas
+for improvements.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+google-play-scraper>=1.2.7

--- a/reviews_extraction.py
+++ b/reviews_extraction.py
@@ -1,57 +1,266 @@
-#load webdriver function from selenium
-from selenium import webdriver
-from time import sleep
-from bs4 import BeautifulSoup, Comment
-import pandas as pd
+#!/usr/bin/env python3
+"""Command line tool for downloading Google Play Store reviews."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from google_play_scraper import Sort, reviews
 
 
-#Setting up Chrome webdriver Options
-chrome_options = webdriver.ChromeOptions()
+SORT_CHOICES = {
+    "relevant": Sort.MOST_RELEVANT,
+    "newest": Sort.NEWEST,
+    "rating": Sort.RATING,
+}
 
-#setting  up local path of chrome binary file 
-chrome_options.binary_location = "C:\\Users\\SA31\\Downloads\\dt\\Win_337026_chrome-win32\\chrome-win32\\chrome.exe"
 
-#creating Chrome webdriver instance with the set chrome_options
-driver = webdriver.Chrome(chrome_options=chrome_options)
-link = "https://play.google.com/store/apps/details?id=uk.co.o2.android.myo2&hl=en_GB"
-driver.get(link)
-#driver.execute_script("window.scrollTo(0, document.body.scrollHeight)")
-Ptitle = driver.find_element_by_class_name('id-app-title').text.replace(' ','')
-print(Ptitle)
-#driver.find_element_by_xpath('//*[@id="body-content"]/div/div/div[1]/div[2]/div[2]/div[1]/div[4]/button[2]/div[2]').click()
+def positive_int(value: str) -> int:
+    """Argparse helper that ensures a strictly positive integer."""
 
-sleep(1)
-driver.find_element_by_xpath('//*[@id="body-content"]/div/div/div[1]/div[2]/div[2]/div[1]/div[4]/button[2]/div[2]/div/div').click()
-#select_newest.select_by_visible_text('Newest')                       
-#driver.find_element_by_xpath('//*[@id="body-content"]/div/div/div[1]/div[2]/div[2]/div[1]/div[4]/button[2]/div[2]/div/div').click()
-sleep(2)
-#driver.find_element_by_css_selector('.review-filter.id-review-sort-filter.dropdown-menu-container').click()
-driver.find_element_by_css_selector('.displayed-child').click()
-#driver.find_element_by_xpath("//button[@data-dropdown-value='1']").click()
-driver.execute_script("document.querySelectorAll('button.dropdown-child')[0].click()")
-reviews_df = []
-for i in range(1,5):
     try:
-        for elem in driver.find_elements_by_class_name('single-review'):
-            print(str(i))
-            content = elem.get_attribute('outerHTML')
-            soup = BeautifulSoup(content, "html.parser")
-            #print(soup.prettify())
-            date = soup.find('span',class_='review-date').get_text()
-            rating = soup.find('div',class_='tiny-star')['aria-label'][6:7]
-            title = soup.find('span',class_='review-title').get_text()
-            txt = soup.find('div',class_='review-body').get_text().replace('Full Review','')[len(title)+1:]
-            print(soup.get_text())
-            temp = pd.DataFrame({'Date':date,'Rating':rating,'Review Title':title,'Review Text':txt},index=[0])
-            print('-'*10)
-            reviews_df.append(temp)
-            #print(elem)
-    except:
-        print('s')
-    driver.find_element_by_xpath('//*[@id="body-content"]/div/div/div[1]/div[2]/div[2]/div[1]/div[4]/button[2]/div[2]/div/div').click()
-reviews_df = pd.concat(reviews_df,ignore_index=True)
+        parsed = int(value)
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
-reviews_df.to_csv(Ptitle+'_reviews_list.csv', encoding='utf-8')
- 
-#driver.close()
-    
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download Google Play Store reviews for the given app id and "
+            "save them to a CSV or JSON file."
+        )
+    )
+
+    parser.add_argument(
+        "app_id",
+        help="Google Play application id, e.g. com.spotify.music",
+    )
+    parser.add_argument(
+        "-n",
+        "--count",
+        type=positive_int,
+        default=100,
+        help="Maximum number of reviews to download (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--lang",
+        default="en",
+        help="Two-letter language code to request (default: %(default)s).",
+        metavar="LANG",
+    )
+    parser.add_argument(
+        "--country",
+        default="us",
+        help="Two-letter country code to request (default: %(default)s).",
+        metavar="COUNTRY",
+    )
+    parser.add_argument(
+        "--sort",
+        choices=sorted(SORT_CHOICES.keys()),
+        default="newest",
+        help="Sort order to use for reviews (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--score",
+        type=int,
+        choices=[1, 2, 3, 4, 5],
+        help="Optional star rating (1-5) to filter reviews after download.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output path. Defaults to <app-id>.<format> for file output.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["csv", "json"],
+        default="csv",
+        help="Output format (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow overwriting an existing output file.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def _isoformat(value):
+    """Return ISO formatted timestamps or ``None`` for non-datetime values."""
+
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return value if value is not None else None
+
+
+def _normalise_review(review: Dict[str, object]) -> Dict[str, object]:
+    """Convert the google-play-scraper review into a serialisable dict."""
+
+    return {
+        "review_id": review.get("reviewId"),
+        "user_name": review.get("userName"),
+        "user_image": review.get("userImage"),
+        "score": review.get("score"),
+        "thumbs_up_count": review.get("thumbsUpCount"),
+        "review_created_version": review.get("reviewCreatedVersion"),
+        "app_version": review.get("appVersion"),
+        "content": review.get("content"),
+        "reply_content": review.get("replyContent"),
+        "at": _isoformat(review.get("at")),
+        "replied_at": _isoformat(review.get("repliedAt")),
+    }
+
+
+def fetch_reviews(
+    app_id: str,
+    *,
+    lang: str = "en",
+    country: str = "us",
+    sort: Sort = Sort.NEWEST,
+    count: int = 100,
+    score: Optional[int] = None,
+) -> List[Dict[str, object]]:
+    """Download reviews using ``google-play-scraper``.
+
+    Parameters are equivalent to the CLI flags. ``count`` controls the maximum
+    number of reviews returned after normalisation. When ``score`` is provided,
+    the filter happens after fetching reviews from Google Play; therefore fewer
+    than ``count`` items may be returned if there are not enough matching
+    entries.
+    """
+
+    collected: List[Dict[str, object]] = []
+    token = None
+
+    while len(collected) < count:
+        batch_size = min(200, count - len(collected))
+        result, token = reviews(
+            app_id,
+            lang=lang,
+            country=country,
+            sort=sort,
+            count=batch_size,
+            continuation_token=token,
+        )
+
+        if not result:
+            break
+
+        if score is not None:
+            result = [item for item in result if item.get("score") == score]
+
+        for item in result:
+            collected.append(_normalise_review(item))
+            if len(collected) >= count:
+                break
+
+        if not token:
+            break
+
+    return collected
+
+
+def _write_csv(rows: Iterable[Dict[str, object]], path: str) -> None:
+    """Persist rows to ``path`` in CSV format."""
+
+    rows = list(rows)
+    fieldnames = [
+        "review_id",
+        "user_name",
+        "user_image",
+        "score",
+        "thumbs_up_count",
+        "review_created_version",
+        "app_version",
+        "content",
+        "reply_content",
+        "at",
+        "replied_at",
+    ]
+
+    with open(path, "w", encoding="utf-8", newline="") as file_obj:
+        writer = csv.DictWriter(file_obj, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_json(rows: Iterable[Dict[str, object]], path: Optional[str]) -> None:
+    """Persist rows as JSON. When ``path`` is ``None`` output to stdout."""
+
+    serialisable = list(rows)
+
+    if path:
+        with open(path, "w", encoding="utf-8") as file_obj:
+            json.dump(serialisable, file_obj, indent=2, ensure_ascii=False)
+            file_obj.write("\n")
+    else:
+        json.dump(serialisable, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Entry point for the CLI."""
+
+    args = parse_args(argv)
+    sort = SORT_CHOICES[args.sort]
+
+    try:
+        reviews_list = fetch_reviews(
+            args.app_id,
+            lang=args.lang,
+            country=args.country,
+            sort=sort,
+            count=args.count,
+            score=args.score,
+        )
+    except Exception as exc:  # pragma: no cover - defensive programming
+        print(f"Failed to download reviews: {exc}", file=sys.stderr)
+        return 1
+
+    if not reviews_list:
+        print("No reviews returned for the specified parameters.", file=sys.stderr)
+        return 0
+
+    if args.format == "csv":
+        output_path = args.output or f"{args.app_id.replace('.', '_')}_reviews.csv"
+        if os.path.exists(output_path) and not args.overwrite:
+            print(
+                f"Refusing to overwrite existing file '{output_path}'. "
+                "Use --overwrite to replace it.",
+                file=sys.stderr,
+            )
+            return 1
+        _write_csv(reviews_list, output_path)
+        print(f"Saved {len(reviews_list)} reviews to {output_path}")
+    else:
+        output_path = args.output
+        if output_path and os.path.exists(output_path) and not args.overwrite:
+            print(
+                f"Refusing to overwrite existing file '{output_path}'. "
+                "Use --overwrite to replace it.",
+                file=sys.stderr,
+            )
+            return 1
+        _write_json(reviews_list, output_path)
+        if output_path:
+            print(f"Saved {len(reviews_list)} reviews to {output_path}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- replace the obsolete Selenium scraping script with an argparse-based CLI that pulls reviews via google-play-scraper and supports CSV/JSON output as well as filtering options
- refresh the README with instructions, usage examples and troubleshooting guidance
- add a requirements.txt listing the google-play-scraper dependency

## Testing
- python reviews_extraction.py --help
- python reviews_extraction.py com.spotify.music --count 5 --format json
- python reviews_extraction.py com.spotify.music --count 5 --overwrite


------
https://chatgpt.com/codex/tasks/task_e_68c853c4408c832088b4800eb7092621