### PR TITLE
Add GitHub Actions workflow for pytest tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs pytest on push and pull requests across Python 3.9 through 3.11
- install project requirements and pytest before running the test suite

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c856a8376483209e768f07d629b59a