### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/amrrs/Google-Play-Store-Review-Extractor/actions/workflows/tests.yml/badge.svg)](https://github.com/amrrs/Google-Play-Store-Review-Extractor/actions/workflows/tests.yml)
+
 # Google Play Store Review Extractor
 
 Modern command line utility for downloading reviews of an Android application


### PR DESCRIPTION
## Summary
- add GitHub Actions CI status badge to the top of the README pointing to tests.yml

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c856a9906483209ba1992453084ade